### PR TITLE
Added support for Azure AD authentication for Linux and Windows

### DIFF
--- a/ext_aad.tf
+++ b/ext_aad.tf
@@ -1,0 +1,10 @@
+resource "azurerm_virtual_machine_extension" "azure_ad_join" {
+  count = var.azure_ad_join ? 1 : 0
+  name = "AADLoginForWindows"
+  virtual_machine_id = azurerm_windows_virtual_machine.vm.id
+  publisher = "Microsoft.Azure.ActiveDirectory"
+  type = "AADLoginForWindows"
+  type_handler_version = "1.0"
+
+  tags                         = var.tags
+}

--- a/ext_aad.tf
+++ b/ext_aad.tf
@@ -1,10 +1,9 @@
 resource "azurerm_virtual_machine_extension" "azure_ad_join" {
   count = var.azure_ad_join ? 1 : 0
-  name = "AADLoginForWindows"
-  virtual_machine_id = azurerm_windows_virtual_machine.vm.id
+  name = local.os_type == "windows" ? "AADLoginForWindows" : "AADSSHLoginForLinux"
+  virtual_machine_id = local.os_type == "windows" ? azurerm_windows_virtual_machine.machine[0].id : azurerm_linux_virtual_machine.machine[0].id
   publisher = "Microsoft.Azure.ActiveDirectory"
-  type = "AADLoginForWindows"
+  type = local.os_type == "windows" ? "AADLoginForWindows" : "AADSSHLoginForLinux"
   type_handler_version = "1.0"
-
   tags                         = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -154,3 +154,8 @@ variable "adds_join" {
   })
   default = null
 }
+
+variable "azure_ad_join" {
+description = "Whether to join the virtual machine to Azure Active Directory"
+default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -157,5 +157,5 @@ variable "adds_join" {
 
 variable "azure_ad_join" {
 description = "Whether to join the virtual machine to Azure Active Directory"
-default = null
+default = false
 }

--- a/vm_linux.tf
+++ b/vm_linux.tf
@@ -68,4 +68,12 @@ resource "azurerm_linux_virtual_machine" "machine" {
       version   = var.source_image_reference.version
     }
   }
+
+  dynamic "identity" {
+    for_each = var.azure_ad_join != false ? ["identity"] : []
+    content {
+        type = "SystemAssigned"
+    }
+  }
+
 }

--- a/vm_windows.tf
+++ b/vm_windows.tf
@@ -60,12 +60,12 @@ resource "azurerm_windows_virtual_machine" "machine" {
       version   = var.source_image_reference.version
     }
   }
-  
-dynamic "identity" {
-  for_each = var.azure_ad_join != null ? ["identity"] : []
-  content {
-      type = "SystemAssigned"
+
+  dynamic "identity" {
+    for_each = var.azure_ad_join != false ? ["identity"] : []
+    content {
+        type = "SystemAssigned"
+    }
   }
-}
 
 }

--- a/vm_windows.tf
+++ b/vm_windows.tf
@@ -60,5 +60,12 @@ resource "azurerm_windows_virtual_machine" "machine" {
       version   = var.source_image_reference.version
     }
   }
+  
+dynamic "identity" {
+  for_each = var.azure_ad_join != null ? ["identity"] : []
+  content {
+      type = "SystemAssigned"
+  }
 }
 
+}


### PR DESCRIPTION
Setting azure_ad_join = true will provision a System Managed identity for the VM in Azure AD as well as installs the appropriate VM extension for enabling Azure AD authentication.

Resolves issue https://github.com/crayon/terraform-azurerm-vm/issues/1