### PR TITLE
Added support for Managed Identities #36

### DIFF
--- a/ext_adds.tf
+++ b/ext_adds.tf
@@ -1,6 +1,5 @@
 resource "azurerm_virtual_machine_extension" "adjoin" {
   for_each = var.adds_join != null ? { "ADDS" = "true" } : {}
-  # for_each             = { for ext in var.adds_join : ext.domain_name => ext }
   name                 = format("%s-adjoin", var.name)
   virtual_machine_id   = local.os_type == "windows" ? azurerm_windows_virtual_machine.machine[0].id : azurerm_linux_virtual_machine.machine[0].id
   publisher            = "Microsoft.Compute"

--- a/ext_adds.tf
+++ b/ext_adds.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_machine_extension" "adjoin" {
-  for_each = var.adds_join != null ? { "ADDS" = "true" } : {}
+  for_each             = var.adds_join != null ? { "ADDS" = "true" } : {}
   name                 = format("%s-adjoin", var.name)
   virtual_machine_id   = local.os_type == "windows" ? azurerm_windows_virtual_machine.machine[0].id : azurerm_linux_virtual_machine.machine[0].id
   publisher            = "Microsoft.Compute"

--- a/variables.tf
+++ b/variables.tf
@@ -167,3 +167,12 @@ variable "azure_ad_join" {
   type        = bool
   default     = false
 }
+
+variable "identity" {
+  description = "Managed Identity which should be assigned the virtual machine."
+  type = object({
+    type           = string
+    identity_ids   = list(string)
+  })
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -171,8 +171,8 @@ variable "azure_ad_join" {
 variable "identity" {
   description = "Managed Identity which should be assigned the virtual machine."
   type = object({
-    type           = string
-    identity_ids   = list(string)
+    type         = string
+    identity_ids = list(string)
   })
   default = null
 }

--- a/vm_linux.tf
+++ b/vm_linux.tf
@@ -72,7 +72,7 @@ resource "azurerm_linux_virtual_machine" "machine" {
   dynamic "identity" {
     for_each = var.identity != null ? ["identity"] : []
     content {
-      type = var.identity.type
+      type         = var.identity.type
       identity_ids = var.identity.identity_ids
     }
   }

--- a/vm_linux.tf
+++ b/vm_linux.tf
@@ -70,9 +70,10 @@ resource "azurerm_linux_virtual_machine" "machine" {
   }
 
   dynamic "identity" {
-    for_each = var.azure_ad_join != false ? ["identity"] : []
+    for_each = var.identity != null ? ["identity"] : []
     content {
-      type = "SystemAssigned"
+      type = var.identity.type
+      identity_ids = var.identity.identity_ids
     }
   }
 

--- a/vm_windows.tf
+++ b/vm_windows.tf
@@ -64,7 +64,7 @@ resource "azurerm_windows_virtual_machine" "machine" {
   dynamic "identity" {
     for_each = var.identity != null ? ["identity"] : []
     content {
-      type = var.identity.type
+      type         = var.identity.type
       identity_ids = var.identity.identity_ids
     }
   }

--- a/vm_windows.tf
+++ b/vm_windows.tf
@@ -49,7 +49,6 @@ resource "azurerm_windows_virtual_machine" "machine" {
   availability_set_id = var.availability_set_id
   timezone            = var.timezone
 
-
   source_image_id = var.source_image_id.uri
 
   dynamic "source_image_reference" {
@@ -63,9 +62,10 @@ resource "azurerm_windows_virtual_machine" "machine" {
   }
 
   dynamic "identity" {
-    for_each = var.azure_ad_join != false ? ["identity"] : []
+    for_each = var.identity != null ? ["identity"] : []
     content {
-      type = "SystemAssigned"
+      type = var.identity.type
+      identity_ids = var.identity.identity_ids
     }
   }
 


### PR DESCRIPTION
Lets discuss this PR on the next SIG Terraform - Azure Maintainer Forum.

Specifically, is it possible to mark the identity_ids property as optional, so that it does not need to be specified with a null value:

```
identity = {
    type = "SystemAssigned"
    identity_ids = null
  }
```
